### PR TITLE
Errors and Dirty values

### DIFF
--- a/dist/model.d.ts
+++ b/dist/model.d.ts
@@ -10,6 +10,8 @@ export declare class Model<MD extends ModelData> {
     error: PlumpError;
     _write$: Subject<MD>;
     dirty: DirtyValues;
+    _dirty$: Subject<boolean>;
+    dirty$: Observable<boolean>;
     readonly type: any;
     readonly schema: any;
     static empty(id: number | string, error?: string): {

--- a/dist/model.d.ts
+++ b/dist/model.d.ts
@@ -12,14 +12,15 @@ export declare class Model<MD extends ModelData> {
     dirty: DirtyValues;
     readonly type: any;
     readonly schema: any;
-    static empty(id: number | string): {
+    static empty(id: number | string, error?: string): {
         id: string | number;
         type: string;
         empty: boolean;
+        error: string;
         attributes: {};
         relationships: {};
     };
-    empty(id: number | string): MD;
+    empty(id: number | string, error?: string): MD;
     dirtyFields(): string[];
     constructor(opts: Attributed, plump: Plump);
     $$copyValuesFrom(opts?: Attributed): void;

--- a/dist/model.js
+++ b/dist/model.js
@@ -67,8 +67,8 @@ var Model = exports.Model = function () {
 
     _createClass(Model, [{
         key: 'empty',
-        value: function empty(id) {
-            return this.constructor['empty'](id);
+        value: function empty(id, error) {
+            return this.constructor['empty'](id, error);
         }
     }, {
         key: 'dirtyFields',
@@ -247,10 +247,13 @@ var Model = exports.Model = function () {
                     var terminal$ = _rxjs.Observable.fromPromise(terminal.read(readReq).then(function (terminalValue) {
                         if (terminalValue === null) {
                             throw new _errors.NotFoundError();
+                            // return null;
                         } else {
                             return terminalValue;
                         }
-                    }));
+                    })).catch(function () {
+                        return _rxjs.Observable.of(_this5.empty(_this5.id, 'load error'));
+                    });
                     var cold$ = _rxjs.Observable.from(colds).flatMap(function (s) {
                         return _rxjs.Observable.fromPromise(s.read(readReq));
                     });
@@ -352,13 +355,14 @@ var Model = exports.Model = function () {
         }
     }], [{
         key: 'empty',
-        value: function empty(id) {
+        value: function empty(id, error) {
             var _this6 = this;
 
             var retVal = {
                 id: id,
                 type: this.type,
                 empty: true,
+                error: error,
                 attributes: {},
                 relationships: {}
             };

--- a/dist/model.js
+++ b/dist/model.js
@@ -49,6 +49,8 @@ var Model = exports.Model = function () {
 
         this.plump = plump;
         this._write$ = new _rxjs.Subject();
+        this._dirty$ = new _rxjs.Subject();
+        this.dirty$ = this._dirty$.asObservable().startWith(false);
         this.error = null;
         if (this.type === 'BASE') {
             throw new TypeError('Cannot instantiate base plump Models, please subclass with a schema and valid type');
@@ -130,6 +132,7 @@ var Model = exports.Model = function () {
                     type: this.type
                 });
             }
+            this._dirty$.next(this.dirtyFields().length !== 0);
         }
     }, {
         key: 'get',

--- a/dist/observers.js
+++ b/dist/observers.js
@@ -51,10 +51,16 @@ function observeList(list, plump) {
             return _rxjs.Observable.of([]);
         } else {
             return _rxjs.Observable.combineLatest(coms.map(function (ed) {
-                return ed.model.asObservable(['attributes']).map(function (v) {
+                return ed.model.asObservable(['attributes']).catch(function () {
+                    return _rxjs.Observable.of(ed.model.empty());
+                }).map(function (v) {
                     return Object.assign(v, { meta: ed.meta });
                 });
-            }));
+            })).map(function (children) {
+                return children.filter(function (child) {
+                    return !child.empty;
+                });
+            });
         }
     }).startWith([]).shareReplay(1);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plump",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Pluggable Datastore",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/model.ts
+++ b/src/model.ts
@@ -56,11 +56,12 @@ export class Model<MD extends ModelData> {
     return this.constructor['schema'];
   }
 
-  static empty(id: number | string) {
+  static empty(id: number | string, error?: string) {
     const retVal = {
       id: id,
       type: this.type,
       empty: true,
+      error: error,
       attributes: {},
       relationships: {},
     };
@@ -90,8 +91,8 @@ export class Model<MD extends ModelData> {
     return retVal;
   }
 
-  empty(id: number | string): MD {
-    return this.constructor['empty'](id);
+  empty(id: number | string, error?: string): MD {
+    return this.constructor['empty'](id, error);
   }
 
   dirtyFields() {
@@ -289,11 +290,14 @@ export class Model<MD extends ModelData> {
             terminal.read(readReq).then(terminalValue => {
               if (terminalValue === null) {
                 throw new NotFoundError();
+                // return null;
               } else {
                 return terminalValue;
               }
             }),
-          );
+          ).catch(() => {
+            return Observable.of(this.empty(this.id, 'load error'));
+          });
           const cold$ = Observable.from(colds).flatMap((s: CacheStore) =>
             Observable.fromPromise(s.read(readReq)),
           );

--- a/src/model.ts
+++ b/src/model.ts
@@ -43,10 +43,12 @@ export class Model<MD extends ModelData> {
     relationships: {},
   };
 
-  public error: PlumpError;
+  error: PlumpError;
 
-  public _write$: Subject<MD> = new Subject<MD>();
-  public dirty: DirtyValues;
+  _write$: Subject<MD> = new Subject<MD>();
+  dirty: DirtyValues;
+  _dirty$ = new Subject<boolean>();
+  dirty$ = this._dirty$.asObservable().startWith(false);
 
   get type() {
     return this.constructor['type'];
@@ -166,6 +168,7 @@ export class Model<MD extends ModelData> {
         type: this.type,
       } as MD);
     }
+    this._dirty$.next(this.dirtyFields().length !== 0);
   }
 
   get<T extends ModelData>(req: ReadRequest): Promise<T> {


### PR DESCRIPTION
Model observers are now a bit more robust in handling errors (filtering them out when an observed child enters an error state, usually 404 or 401).

Models also now have a dirty$ observable, which is just a boolean observable to say if there's anything that needs saving. Use with a debounce to autosave or indicate save status to the user.